### PR TITLE
refactor:structure tauri backend

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
  "rustc_version",
  "toml 0.7.4",
  "vswhom",
- "winreg",
+ "winreg 0.11.0",
 ]
 
 [[package]]
@@ -1357,6 +1357,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,10 +1443,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-range"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "huehuehue"
@@ -1437,8 +1479,8 @@ dependencies = [
  "futures-util",
  "log",
  "mdns",
- "once_cell",
  "reachable",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",
@@ -1451,6 +1493,43 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.6",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1570,6 +1649,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
@@ -1817,6 +1902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +1926,24 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2001,6 +2110,50 @@ checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
 dependencies = [
  "pathdiff",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2479,6 +2632,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [
+ "base64 0.21.2",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +2738,29 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -2617,6 +2839,18 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.6",
+ "ryu",
  "serde",
 ]
 
@@ -3293,6 +3527,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,6 +3592,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -3405,6 +3669,12 @@ checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
 dependencies = [
  "serde_json",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -3485,6 +3755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,6 +3812,15 @@ checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3957,6 +4242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "thiserror",
  "tokio",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1479,9 +1479,11 @@ dependencies = [
  "futures-util",
  "log",
  "mdns",
+ "paste",
  "reachable",
  "reqwest",
  "serde",
+ "serde_derive",
  "serde_json",
  "tauri",
  "tauri-build",
@@ -2215,6 +2217,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pathdiff"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,9 +30,10 @@ futures-util = "0.3.28"
 log = "0.4.19"
 env_logger = "0.10.0"
 reachable = "0.2.2"
-reqwest = "0.11.18"
+reqwest = { version = "0.11.18", features = ["json"] }
 paste = "1.0.12"
 serde_derive = "1.0.164"
+thiserror = "1.0.40"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,8 +29,8 @@ mdns = "3.0.0"
 futures-util = "0.3.28"
 log = "0.4.19"
 env_logger = "0.10.0"
-once_cell = "1.18.0"
 reachable = "0.2.2"
+reqwest = "0.11.18"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,8 @@ log = "0.4.19"
 env_logger = "0.10.0"
 reachable = "0.2.2"
 reqwest = "0.11.18"
+paste = "1.0.12"
+serde_derive = "1.0.164"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/endpoints.rs
+++ b/src-tauri/endpoints.rs
@@ -1,0 +1,56 @@
+#[allow(unused_imports)]
+use crate::transfer::*;
+
+get!("/resource", resources, HueV2ResourceResponse);
+get!("/resource/{id}", resource, HueV2ResourceResponse, [id]);
+get!("/resource/light", lights, HueV2LightResponse);
+get!("/resource/light/{id}", light, HueV2LightResponse, [id]);
+get!("/resource/scene", scenes, HueV2SceneResponse);
+get!("/resource/scene/{id}", scene, HueV2SceneResponse, [id]);
+get!("/resource/room", rooms, HueV2RoomResponse);
+get!("/resource/room/{id}", room, HueV2RoomResponse, [id]);
+get!("/resource/zone", zones, HueV2ZoneResponse);
+get!("/resource/zone/{id}", zone, HueV2ZoneResponse, [id]);
+get!(
+    "/resource/bridge_home",
+    bridge_homes,
+    HueV2BridgeHomeResponse
+);
+get!(
+    "/resource/bridge_home/{id}",
+    bridge_home,
+    HueV2BridgeHomeResponse,
+    [id]
+);
+get!(
+    "/resource/grouped_light",
+    grouped_lights,
+    HueV2GroupedLightResponse
+);
+get!(
+    "/resource/grouped_light/{id}",
+    grouped_light,
+    HueV2GroupedLightResponse,
+    [id]
+);
+get!("/resource/device", devices, HueV2DeviceResponse);
+get!("/resource/device/{id}", device, HueV2DeviceResponse, [id]);
+
+handlers!(
+    get_resources,
+    get_resource,
+    get_lights,
+    get_light,
+    get_scenes,
+    get_scene,
+    get_rooms,
+    get_room,
+    get_zones,
+    get_zone,
+    get_bridge_homes,
+    get_bridge_home,
+    get_grouped_lights,
+    get_grouped_light,
+    get_devices,
+    get_device
+);

--- a/src-tauri/endpoints.rs
+++ b/src-tauri/endpoints.rs
@@ -35,6 +35,76 @@ get!(
 );
 get!("/resource/device", devices, HueV2DeviceResponse);
 get!("/resource/device/{id}", device, HueV2DeviceResponse, [id]);
+get!("/resource/bridge", bridges, HueV2BridgeResponse);
+get!("/resource/bridge/{id}", bridge, HueV2BridgeResponse, [id]);
+get!(
+    "/resource/device_power",
+    device_powers,
+    HueV2DevicePowerResponse
+);
+get!(
+    "/resource/device_power/{id}",
+    device_power,
+    HueV2DevicePowerResponse,
+    [id]
+);
+get!(
+    "/resource/zigbee_connectivity",
+    zigbee_connectivities,
+    HueV2ZigbeeConnectivityResponse
+);
+get!(
+    "/resource/zigbee_connectivity/{id}",
+    zigbee_connectivity,
+    HueV2ZigbeeConnectivityResponse,
+    [id]
+);
+get!(
+    "/resource/zgp_connectivity",
+    zgp_connectivities,
+    HueV2ZgpConnectivityResponse
+);
+get!(
+    "/resource/zgp_connectivity/{id}",
+    zgp_connectivity,
+    HueV2ZgpConnectivityResponse,
+    [id]
+);
+get!(
+    "/resource/zigbee_device_discovery",
+    zigbee_device_discovery,
+    HueV2ZigbeeDeviceDiscoveryResponse
+);
+get!(
+    "/resource/zigbee_device_discovery/{id}",
+    zigbee_device_discoveries,
+    HueV2ZigbeeDeviceDiscoveryResponse,
+    [id]
+);
+get!("/resource/motion", motions, HueV2MotionResponse);
+get!("/resource/motion/{id}", motion, HueV2MotionResponse, [id]);
+get!(
+    "/resource/temperature",
+    temperatures,
+    HueV2TemperatureResponse
+);
+get!(
+    "/resource/temperature/{id}",
+    temperature,
+    HueV2TemperatureResponse,
+    [id]
+);
+get!(
+    "/resource/light_level",
+    light_levels,
+    HueV2LightLevelResponse
+);
+get!(
+    "/resource/light_level/{id}",
+    light_level,
+    HueV2LightLevelResponse,
+    [id]
+);
 
 handlers!(
     get_resources,
@@ -52,5 +122,19 @@ handlers!(
     get_grouped_lights,
     get_grouped_light,
     get_devices,
-    get_device
+    get_device,
+    get_bridges,
+    get_bridge,
+    get_device_powers,
+    get_device_power,
+    get_zigbee_connectivities,
+    get_zigbee_connectivity,
+    get_zgp_connectivities,
+    get_zgp_connectivity,
+    get_zigbee_device_discoveries,
+    get_zigbee_device_discovery,
+    get_temperatures,
+    get_temperature,
+    get_light_levels,
+    get_light_level
 );

--- a/src-tauri/lib.rs
+++ b/src-tauri/lib.rs
@@ -12,6 +12,7 @@ use std::{collections::HashSet, net::IpAddr, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
 const HUE_BRIDGE_SERVICE_NAME: &str = "_hue._tcp.local";
+const HUE_BRIDGE_SERVICE_QUERY_INTERVAL_SECONDS: u64 = 3600;
 const HUE_BRIDGE_API_BASE_URL: &str = "/clip/v2";
 
 #[derive(Debug, Default)]
@@ -56,8 +57,11 @@ impl HueHueHue {
                 "initiating hue bridge discovery mDNS query service for address \"{}\"...",
                 HUE_BRIDGE_SERVICE_NAME
             );
-            let stream =
-                mdns::discover::all(HUE_BRIDGE_SERVICE_NAME, Duration::from_secs(15))?.listen();
+            let stream = mdns::discover::all(
+                HUE_BRIDGE_SERVICE_NAME,
+                Duration::from_secs(HUE_BRIDGE_SERVICE_QUERY_INTERVAL_SECONDS),
+            )?
+            .listen();
             pin_mut!(stream);
 
             while let Some(Ok(resp)) = stream.next().await {

--- a/src-tauri/lib.rs
+++ b/src-tauri/lib.rs
@@ -1,3 +1,5 @@
+pub mod transfer;
+
 use futures_util::{pin_mut, stream::StreamExt};
 use log::info;
 use mdns::RecordKind;

--- a/src-tauri/lib.rs
+++ b/src-tauri/lib.rs
@@ -1,30 +1,39 @@
 use futures_util::{pin_mut, stream::StreamExt};
 use log::info;
 use mdns::RecordKind;
-use once_cell::sync::Lazy;
 use reachable::*;
 use std::{
-    collections::HashSet, error::Error, fmt::Display, net::IpAddr, sync::Mutex, time::Duration,
+    collections::HashSet,
+    error::Error,
+    fmt::Display,
+    net::IpAddr,
+    sync::{Arc, Mutex},
+    time::Duration,
 };
 
-macro_rules! lazy_lock {
-    ($s:expr) => {
-        &mut (*$s.lock().unwrap())
-    };
+const HUE_BRIDGE_SERVICE_NAME: &str = "_hue._tcp.local";
+
+#[derive(Debug, Default)]
+pub struct HueHueHueConfig {}
+
+#[derive(Debug, Default)]
+pub struct HueHueHue {
+    _config: HueHueHueConfig,
+    bridge_ip_addrs: Arc<Mutex<HashSet<IpAddr>>>,
 }
 
-const HUE_BRIDGE_SERVICE_NAME: &str = "_hue._tcp.local";
-static HUE_BRIDGE_IP_ADDRESSES: Lazy<Mutex<HashSet<IpAddr>>> =
-    Lazy::new(|| Mutex::new(HashSet::new()));
+pub struct HueHueHueState(pub Mutex<HueHueHue>);
 
 #[derive(Debug)]
-pub enum HueHueHueError {}
+pub enum HueHueHueError {
+    SynchronizationError,
+}
 
 impl Display for HueHueHueError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         let desc = match self {
-            _ => "unknown error occured in huehuehue",
+            HueHueHueError::SynchronizationError => "synchronization error",
         };
         write!(f, "{}", desc)
     }
@@ -32,37 +41,40 @@ impl Display for HueHueHueError {
 
 impl Error for HueHueHueError {}
 
-pub async fn discover() -> Result<(), Box<dyn Error + Send + Sync>> {
-    info!(
-        "initiating hue bridge discovery mDNS query service for address \"{}\"...",
-        HUE_BRIDGE_SERVICE_NAME
-    );
-    let stream = mdns::discover::all(HUE_BRIDGE_SERVICE_NAME, Duration::from_secs(15))?.listen();
-    pin_mut!(stream);
-
-    while let Some(Ok(resp)) = stream.next().await {
-        let addr: Option<IpAddr> = resp.records().find_map(|r| match r.kind {
-            RecordKind::A(addr) => Some(addr.into()),
-            RecordKind::AAAA(addr) => Some(addr.into()),
-            _ => None,
-        });
-        if let Some(addr) = addr {
+impl HueHueHue {
+    pub fn discover(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let addrs = self.bridge_ip_addrs.clone();
+        tokio::spawn(async move {
             info!(
-                "mDNS response to service name query \"{}\" received from \"{}\"",
-                HUE_BRIDGE_SERVICE_NAME, &addr
+                "initiating hue bridge discovery mDNS query service for address \"{}\"...",
+                HUE_BRIDGE_SERVICE_NAME
             );
-            let addrs = lazy_lock!(HUE_BRIDGE_IP_ADDRESSES);
-            for addr in addrs.clone().iter() {
-                if Into::<IcmpTarget>::into(*addr)
-                    .check_availability()
-                    .is_err()
-                {
-                    addrs.remove(addr);
+            let stream =
+                mdns::discover::all(HUE_BRIDGE_SERVICE_NAME, Duration::from_secs(15))?.listen();
+            pin_mut!(stream);
+
+            while let Some(Ok(resp)) = stream.next().await {
+                let addr: Option<IpAddr> = resp.records().find_map(|r| match r.kind {
+                    RecordKind::A(addr) => Some(addr.into()),
+                    RecordKind::AAAA(addr) => Some(addr.into()),
+                    _ => None,
+                });
+                if let Some(addr) = addr {
+                    info!(
+                        "mDNS response to service name query \"{}\" received from \"{}\"",
+                        HUE_BRIDGE_SERVICE_NAME, &addr
+                    );
+                    let mut addrs = addrs
+                        .lock()
+                        .map_err(|_| HueHueHueError::SynchronizationError)?;
+                    addrs.retain(|e| Into::<IcmpTarget>::into(*e).check_availability().is_ok());
+                    addrs.insert(addr);
                 }
             }
-            addrs.insert(addr);
-        }
-    }
 
-    Ok(())
+            Ok::<(), Box<dyn Error + Send + Sync>>(())
+        });
+
+        Ok(())
+    }
 }

--- a/src-tauri/macros.rs
+++ b/src-tauri/macros.rs
@@ -1,0 +1,94 @@
+#![allow(unused_macros)]
+
+macro_rules! endpoint {
+    ($method:expr, $endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        paste::paste! {
+            impl crate::HueHueHue {
+                pub async fn [<$method:lower _ $endpointname>](&self $(, body: $body)? $(, $($param: impl Into<String>),+)?) -> Result<$returntype, crate::HueHueHueError> {
+                    #[allow(unused_mut)]
+                    let mut endpoint: String = $endpoint.into();
+                    $($(endpoint = endpoint.replace(format!("{{{}}}", stringify!($param)).as_str(), $param.into().as_str()));+;)?
+                    let res = self.client.[<$method:lower>](format!("{}{}",self.get_base_url(), endpoint))
+                        $(.json(&(body as $body)))?
+                        .send()
+                        .await?
+                        .json()
+                        .await?;
+
+                    Ok(res)
+                }
+            }
+
+            #[tauri::command]
+            pub async fn [<$method:lower _ $endpointname>]($(body: $body, )? $($($param: String),+,)? state: tauri::State<'_, crate::HueHueHueState>) -> Result<$returntype, crate::HueHueHueError> {
+                let huehuehue = state.0.lock().await;
+                crate::HueHueHue::[<$method:lower _ $endpointname>](&huehuehue $(,body as $body)? $(,$($param)+)?).await
+            }
+        }
+    };
+}
+
+macro_rules! get {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(get, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! head {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(head, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! post {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(post, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! put {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(put, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! delete {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(delete, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! connect {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(connect, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! options {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(options, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! trace {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(trace, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! patch {
+    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
+        endpoint!(patch, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+    };
+}
+
+macro_rules! handlers {
+    ($($handler:ident),*) => {
+        #[macro_export]
+        macro_rules! huehuehue_handlers {
+            ($app:expr) => {
+                $app.invoke_handler(tauri::generate_handler![$($handler,)*])
+            };
+        }
+    };
+}

--- a/src-tauri/main.rs
+++ b/src-tauri/main.rs
@@ -1,27 +1,26 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::error::Error;
-
+use huehuehue::endpoints::*;
+use huehuehue::huehuehue_handlers;
+use huehuehue::HueHueHue;
+use huehuehue::HueHueHueError;
 use huehuehue::HueHueHueState;
 use log::info;
-use tauri::{Manager, RunEvent};
+use tauri::RunEvent;
+use tokio::sync::Mutex;
 
 #[tokio::main]
-pub async fn main() -> Result<(), Box<dyn Error>> {
+pub async fn main() -> Result<(), HueHueHueError> {
     env_logger::init_from_env(
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
     );
     tauri::async_runtime::set(tokio::runtime::Handle::current());
     info!("starting huehuehue...");
-    tauri::Builder::default()
-        .manage(HueHueHueState(Default::default()))
-        .setup(|app| {
-            let state = app.state::<HueHueHueState>();
-            state.0.lock().unwrap().discover().unwrap();
-
-            Ok(())
-        })
+    let huehuehue: HueHueHue = HueHueHue::default();
+    huehuehue.discover()?;
+    huehuehue_handlers!(tauri::Builder::default())
+        .manage(HueHueHueState(Mutex::new(huehuehue)))
         .build(tauri::generate_context!())
         .expect("error building tauri app")
         .run(|_, event| match event {

--- a/src-tauri/transfer.rs
+++ b/src-tauri/transfer.rs
@@ -34,7 +34,8 @@ macro_rules! hue_v2_res_get {
 }
 
 #[derive(Debug, Deserialize)]
-pub enum HueV2ResourceGetType {
+#[serde(rename_all = "snake_case")]
+pub enum HueV2ResourceType {
     Device,
     BridgeHome,
     Room,
@@ -71,61 +72,702 @@ pub enum HueV2ResourceGetType {
 #[derive(Debug, Deserialize)]
 pub struct HueV2ResourceGet {
     id: String,
-    r#type: HueV2ResourceGetType,
-    id_v1: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
 }
 hue_v2_res_get!(HueV2ResourceGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2DeviceGet {}
+#[serde(rename_all = "snake_case")]
+pub enum HueV2ProductArchetype {
+    BridgeV2,
+    UnknownArchetype,
+    ClassicBulb,
+    SultanBulb,
+    FloodBulb,
+    SpotBulb,
+    CandleBulb,
+    LusterBulb,
+    PendantRound,
+    PendantLong,
+    CeilingRound,
+    CeilingSquare,
+    FloorShade,
+    FloorLantern,
+    TableShade,
+    RecessedCeiling,
+    RecessedFloot,
+    SingleSpot,
+    DoubleSpot,
+    TableWash,
+    WallLantern,
+    WallShade,
+    FlexibleLamp,
+    GroundSpot,
+    WallSpot,
+    Plug,
+    HueGo,
+    HueLightstrip,
+    HueIris,
+    HueBloom,
+    Bollard,
+    WallWasher,
+    HuePlay,
+    VintageBulb,
+    VintageCandleBulb,
+    EllipseBulb,
+    TriangleBulb,
+    SmallGlobeBulb,
+    LargeGlobeBulb,
+    EdisonBulb,
+    ChristmasTree,
+    StringLight,
+    HueCentris,
+    HueLightstripTv,
+    HueLightstripPc,
+    HueTube,
+    HueSigne,
+    PendantSpot,
+    CeilingHorizontal,
+    CeilingTube,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2DeviceGetProductData {
+    model_id: String,
+    manufacturer_name: String,
+    product_name: String,
+    product_archetype: HueV2ProductArchetype,
+    certified: bool,
+    software_version: String,
+    hardware_platform_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2DeviceGetMetaData {
+    name: String,
+    archetype: HueV2ProductArchetype,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ResourceIdentifierGet {
+    rid: String,
+    rtype: HueV2ResourceType,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2DeviceGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    product_data: HueV2DeviceGetProductData,
+    metadata: HueV2DeviceGetMetaData,
+    services: Vec<HueV2ResourceIdentifierGet>,
+}
 hue_v2_res_get!(HueV2DeviceGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2BridgeHomeGet {}
+pub struct HueV2BridgeHomeGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    children: Vec<HueV2ResourceIdentifierGet>,
+    services: Vec<HueV2ResourceIdentifierGet>,
+}
 hue_v2_res_get!(HueV2BridgeHomeGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2RoomGet {}
+pub enum HueV2RoomArchetype {
+    LivingRoom,
+    Kitchen,
+    Dining,
+    Bedroom,
+    KidsBedroom,
+    Bathroom,
+    Nursery,
+    Recreation,
+    Office,
+    Gym,
+    Hallway,
+    Toilet,
+    FrontDoor,
+    Garage,
+    Terrace,
+    Garden,
+    Driveway,
+    Carport,
+    Home,
+    Downstairs,
+    Upstairs,
+    TopFloor,
+    Attic,
+    GuestRoom,
+    Staircase,
+    Lounge,
+    ManCave,
+    Computer,
+    Studio,
+    Music,
+    Tv,
+    Reading,
+    Closet,
+    Storage,
+    LaundryRoom,
+    Balcony,
+    Porch,
+    Barbecue,
+    Pool,
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RoomGetMetadata {
+    name: String,
+    archetype: HueV2RoomArchetype,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RoomGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    children: Vec<HueV2ResourceIdentifierGet>,
+    services: Vec<HueV2ResourceIdentifierGet>,
+    metadata: HueV2RoomGetMetadata,
+}
 hue_v2_res_get!(HueV2RoomGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2ZoneGet {}
+pub struct HueV2ZoneGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    children: Vec<HueV2ResourceIdentifierGet>,
+    services: Vec<HueV2ResourceIdentifierGet>,
+    metadata: HueV2RoomGetMetadata,
+}
 hue_v2_res_get!(HueV2ZoneGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2LightGet {}
+pub enum HueV2LightArchetype {
+    UnknownArchetype,
+    ClassicBulb,
+    SultanBulb,
+    FloodBulb,
+    SpotBulb,
+    CandleBulb,
+    LusterBulb,
+    PendantRound,
+    PendantLong,
+    CeilingRound,
+    CeilingSquare,
+    FloorShade,
+    FloorLantern,
+    TableShade,
+    RecessedCeiling,
+    RecessedFloot,
+    SingleSpot,
+    DoubleSpot,
+    TableWash,
+    WallLantern,
+    WallShade,
+    FlexibleLamp,
+    GroundSpot,
+    WallSpot,
+    Plug,
+    HueGo,
+    HueLightstrip,
+    HueIris,
+    HueBloom,
+    Bollard,
+    WallWasher,
+    HuePlay,
+    VintageBulb,
+    VintageCandleBulb,
+    EllipseBulb,
+    TriangleBulb,
+    SmallGlobeBulb,
+    LargeGlobeBulb,
+    EdisonBulb,
+    ChristmasTree,
+    StringLight,
+    HueCentris,
+    HueLightstripTv,
+    HueLightstripPc,
+    HueTube,
+    HueSigne,
+    PendantSpot,
+    CeilingHorizontal,
+    CeilingTube,
+}
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetMetadata {
+    name: String,
+    archetype: HueV2LightArchetype,
+    fixed_mired: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetOn {
+    on: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetDimming {
+    brightness: f64,
+    min_dim_level: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetColorTemperatureMirekSchema {
+    mirek_minimum: u32,
+    mirek_maximum: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetColorTemperature {
+    mirek: u32,
+    mirek_valid: bool,
+    mirek_schema: HueV2LightGetColorTemperatureMirekSchema,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetColorXY {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetColorGamutChannel {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetColorGamut {
+    red: HueV2LightGetColorGamutChannel,
+    green: HueV2LightGetColorGamutChannel,
+    blue: HueV2LightGetColorGamutChannel,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightGetColorGamutType {
+    A,
+    B,
+    C,
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetColor {
+    xy: HueV2LightGetColorXY,
+    gamut: Option<HueV2LightGetColorGamut>,
+    gamut_type: HueV2LightGetColorGamutType,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightDynamicsStatus {
+    DynamicPalette,
+    None,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetDynamics {
+    status: HueV2LightDynamicsStatus,
+    status_values: Vec<String>,
+    speed: f64,
+    speed_valid: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetAlert {
+    action_values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightSignal {
+    NoSignal,
+    OnOff,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetSignalingStatus {
+    signal: HueV2LightSignal,
+    estimated_end: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetSignaling {
+    status: Option<HueV2LightGetSignalingStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightMode {
+    Normal,
+    Streaming,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetGradientColor {
+    xy: HueV2LightGetColorXY,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetGradientPoint {
+    color: HueV2LightGetGradientColor,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightGradientMode {
+    InterpolatedPalette,
+    InterpolatedPaletteMirrored,
+    RandomPixelated,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetGradient {
+    points: Vec<HueV2LightGetGradientPoint>,
+    mode: HueV2LightGradientMode,
+    points_capable: u32,
+    mode_values: Vec<String>,
+    pixel_count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightEffect {
+    Sparkle,
+    Fire,
+    Candle,
+    NoEffect,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetEffects {
+    effect: HueV2LightEffect,
+    status_values: Vec<String>,
+    status: HueV2LightEffect,
+    effect_values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightTimedEffect {
+    Sunrise,
+    NoEffect,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetTimedEffects {
+    effect: HueV2LightTimedEffect,
+    duration: Option<u32>,
+    status_values: Vec<String>,
+    status: HueV2LightTimedEffect,
+    effect_values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightPowerupPreset {
+    Safety,
+    Powerfail,
+    LastOnState,
+    Custom,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightPowerupOnMode {
+    On,
+    Toggle,
+    Previous,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetPowerupOn {
+    mode: HueV2LightPowerupOnMode,
+    on: Option<HueV2LightGetOn>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightPowerupDimmingMode {
+    Dimming,
+    Previous,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetPowerupDimmingBrightness {
+    brightness: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetPowerupDimming {
+    mode: HueV2LightPowerupDimmingMode,
+    dimming: Option<HueV2LightGetPowerupDimmingBrightness>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2LightColorTemperatureMode {
+    ColorTemperature,
+    Color,
+    Previous,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetPowerupColorTemperature {
+    mirek: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetPowerupColorColor {
+    xy: HueV2LightGetColorXY,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetPowerupColor {
+    mode: HueV2LightColorTemperatureMode,
+    color_temperature: Option<HueV2LightGetPowerupColorTemperature>,
+    color: Option<HueV2LightGetPowerupColorColor>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGetPowerup {
+    preset: HueV2LightPowerupPreset,
+    configured: bool,
+    on: HueV2LightGetPowerupOn,
+    dimming: Option<HueV2LightGetPowerupDimming>,
+    color: Option<HueV2LightGetPowerupColor>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    metadata: HueV2LightGetMetadata,
+    on: HueV2LightGetOn,
+    dimming: Option<HueV2LightGetDimming>,
+    color_temperature: Option<HueV2LightGetColorTemperature>,
+    color: Option<HueV2LightGetColor>,
+    dynamics: Option<HueV2LightGetDynamics>,
+    alert: Option<HueV2LightGetAlert>,
+    signaling: Option<HueV2LightGetSignaling>,
+    mode: HueV2LightMode,
+    gradient: Option<HueV2LightGetGradient>,
+    effects: Option<HueV2LightGetEffects>,
+    timed_effects: Option<HueV2LightGetTimedEffects>,
+    powerup: Option<HueV2LightGetPowerup>,
+}
 hue_v2_res_get!(HueV2LightGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2ButtonGet {}
+pub struct HueV2ButtonGetMetadata {
+    control_id: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2ButtonEvent {
+    InitialPress,
+    Repeat,
+    ShortRelease,
+    LongRelease,
+    DoubleShortRelease,
+    LongPress,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ButtonGetButton {
+    last_event: HueV2ButtonEvent,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ButtonGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    metadata: HueV2ButtonGetMetadata,
+    button: HueV2ButtonGetButton,
+}
 hue_v2_res_get!(HueV2ButtonGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2RelativeRotaryGet {}
+#[serde(rename_all = "snake_case")]
+pub enum HueV2RelativeRotaryAction {
+    Start,
+    Repeat,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HueV2RelativeRotaryDirection {
+    ClockWise,
+    CounterClockWise,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RelativeRotaryGetRelativeRotaryRotation {
+    direction: HueV2RelativeRotaryDirection,
+    steps: u32,
+    duration: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RelativeRotaryGetRelativeRotaryEvent {
+    action: HueV2RelativeRotaryAction,
+    rotation: HueV2RelativeRotaryGetRelativeRotaryRotation,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RelativeRotaryGetRelativeRotary {
+    last_event: Option<HueV2RelativeRotaryGetRelativeRotaryEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RelativeRotaryGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    relative_rotary: HueV2RelativeRotaryGetRelativeRotary,
+}
 hue_v2_res_get!(HueV2RelativeRotaryGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2TemperatureGet {}
+pub struct HueV2TemperatureGetTemperature {
+    temperature: f64,
+    temperature_valid: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2TemperatureGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    enabled: bool,
+    temperature: HueV2TemperatureGetTemperature,
+}
 hue_v2_res_get!(HueV2TemperatureGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2LightLevelGet {}
+pub struct HueV2LightLevelGetLevel {
+    light_level: u32,
+    light_level_valid: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightLevelGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    enabled: bool,
+    light: HueV2LightLevelGetLevel,
+}
 hue_v2_res_get!(HueV2LightLevelGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2MotionGet {}
+pub struct HueV2MotionGetMotion {
+    motion: bool,
+    motion_valid: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2MotionGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    enabled: bool,
+    motion: HueV2MotionGetMotion,
+}
 hue_v2_res_get!(HueV2MotionGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2EntertainmentGet {}
+pub struct HueV2EntertainmentGetSegment {
+    start: u32,
+    length: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2EntertainmentGetSegments {
+    configurable: bool,
+    max_segments: u32,
+    segments: Vec<HueV2EntertainmentGetSegment>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2EntertainmentGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    renderer: bool,
+    proxy: bool,
+    equalizer: bool,
+    max_streams: Option<u32>,
+    segments: Option<HueV2EntertainmentGetSegments>,
+}
 hue_v2_res_get!(HueV2EntertainmentGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2GroupedLightGet {}
+pub struct HueV2GroupedLightGetOn {
+    on: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2GroupedLightGetDimming {
+    dimming: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2GroupedLightGetAlert {
+    action_values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2GroupedLightGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    on: Option<HueV2GroupedLightGetOn>,
+    dimming: Option<HueV2GroupedLightGetDimming>,
+    alert: Option<HueV2GroupedLightGetAlert>,
+}
 hue_v2_res_get!(HueV2GroupedLightGet);
 
 #[derive(Debug, Deserialize)]
-pub struct HueV2DevicePowerGet {}
+pub enum HueV2DeviceBatteryState {
+    Normal,
+    Low,
+    Critical,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2DevicePowerGetPowerState {
+    battery_state: Option<HueV2DeviceBatteryState>,
+    battery_level: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2DevicePowerGet {
+    id: String,
+    r#type: HueV2ResourceType,
+    id_v1: Option<String>,
+    owner: HueV2ResourceIdentifierGet,
+    power_state: HueV2DevicePowerGetPowerState,
+}
 hue_v2_res_get!(HueV2DevicePowerGet);
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/transfer.rs
+++ b/src-tauri/transfer.rs
@@ -2,38 +2,32 @@
 
 use core::fmt::Debug;
 use paste::paste;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct HueV2Error {
     description: String,
 }
 
-pub trait HueV2ResGet: Debug {}
+pub trait HueV2Res: Debug {}
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ResourceApi<F: HueV2ResGet> {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ResourceApi<F: HueV2Res> {
     errors: Vec<HueV2Error>,
     data: Vec<F>,
 }
 
-macro_rules! hue_v2_resp {
+macro_rules! hue_v2_res {
     ($v:ident) => {
-        paste! {
+        paste::paste! {
+            impl HueV2Res for $v {}
+
             pub type [<$v Response>] = HueV2ResourceApi<$v>;
         }
     };
 }
 
-macro_rules! hue_v2_res_get {
-    ($v:ident) => {
-        impl HueV2ResGet for $v {}
-
-        hue_v2_resp!($v);
-    };
-}
-
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2ResourceType {
     Device,
@@ -69,15 +63,15 @@ pub enum HueV2ResourceType {
     SmartScene,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ResourceGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Resource {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
 }
-hue_v2_res_get!(HueV2ResourceGet);
+hue_v2_res!(HueV2Resource);
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2ProductArchetype {
     BridgeV2,
@@ -132,8 +126,8 @@ pub enum HueV2ProductArchetype {
     CeilingTube,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2DeviceGetProductData {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2DeviceProductData {
     model_id: String,
     manufacturer_name: String,
     product_name: String,
@@ -143,40 +137,40 @@ pub struct HueV2DeviceGetProductData {
     hardware_platform_type: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2DeviceGetMetaData {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2DeviceMetadata {
     name: String,
     archetype: HueV2ProductArchetype,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ResourceIdentifierGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ResourceIdentifier {
     rid: String,
     rtype: HueV2ResourceType,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2DeviceGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Device {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    product_data: HueV2DeviceGetProductData,
-    metadata: HueV2DeviceGetMetaData,
-    services: Vec<HueV2ResourceIdentifierGet>,
+    product_data: HueV2DeviceProductData,
+    metadata: HueV2DeviceMetadata,
+    services: Vec<HueV2ResourceIdentifier>,
 }
-hue_v2_res_get!(HueV2DeviceGet);
+hue_v2_res!(HueV2Device);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2BridgeHomeGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2BridgeHome {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    children: Vec<HueV2ResourceIdentifierGet>,
-    services: Vec<HueV2ResourceIdentifierGet>,
+    children: Vec<HueV2ResourceIdentifier>,
+    services: Vec<HueV2ResourceIdentifier>,
 }
-hue_v2_res_get!(HueV2BridgeHomeGet);
+hue_v2_res!(HueV2BridgeHome);
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum HueV2RoomArchetype {
     LivingRoom,
     Kitchen,
@@ -220,35 +214,35 @@ pub enum HueV2RoomArchetype {
     Other,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2RoomGetMetadata {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2RoomMetadata {
     name: String,
     archetype: HueV2RoomArchetype,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2RoomGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Room {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    children: Vec<HueV2ResourceIdentifierGet>,
-    services: Vec<HueV2ResourceIdentifierGet>,
-    metadata: HueV2RoomGetMetadata,
+    children: Vec<HueV2ResourceIdentifier>,
+    services: Vec<HueV2ResourceIdentifier>,
+    metadata: HueV2RoomMetadata,
 }
-hue_v2_res_get!(HueV2RoomGet);
+hue_v2_res!(HueV2Room);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ZoneGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Zone {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    children: Vec<HueV2ResourceIdentifierGet>,
-    services: Vec<HueV2ResourceIdentifierGet>,
-    metadata: HueV2RoomGetMetadata,
+    children: Vec<HueV2ResourceIdentifier>,
+    services: Vec<HueV2ResourceIdentifier>,
+    metadata: HueV2RoomMetadata,
 }
-hue_v2_res_get!(HueV2ZoneGet);
+hue_v2_res!(HueV2Zone);
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum HueV2LightArchetype {
     UnknownArchetype,
     ClassicBulb,
@@ -300,128 +294,128 @@ pub enum HueV2LightArchetype {
     CeilingHorizontal,
     CeilingTube,
 }
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetMetadata {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightMetadata {
     name: String,
     archetype: HueV2LightArchetype,
     fixed_mired: Option<u32>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetOn {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightOn {
     on: bool,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetDimming {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightDimming {
     brightness: f64,
     min_dim_level: Option<f64>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetColorTemperatureMirekSchema {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightColorTemperatureMirekSchema {
     mirek_minimum: u32,
     mirek_maximum: u32,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetColorTemperature {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightColorTemperature {
     mirek: u32,
     mirek_valid: bool,
-    mirek_schema: HueV2LightGetColorTemperatureMirekSchema,
+    mirek_schema: HueV2LightColorTemperatureMirekSchema,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetColorXY {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightColorXY {
     x: f64,
     y: f64,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetColorGamutChannel {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightColorGamutChannel {
     x: f64,
     y: f64,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetColorGamut {
-    red: HueV2LightGetColorGamutChannel,
-    green: HueV2LightGetColorGamutChannel,
-    blue: HueV2LightGetColorGamutChannel,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightColorGamut {
+    red: HueV2LightColorGamutChannel,
+    green: HueV2LightColorGamutChannel,
+    blue: HueV2LightColorGamutChannel,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum HueV2LightGetColorGamutType {
+pub enum HueV2LightColorGamutType {
     A,
     B,
     C,
     Other,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetColor {
-    xy: HueV2LightGetColorXY,
-    gamut: Option<HueV2LightGetColorGamut>,
-    gamut_type: HueV2LightGetColorGamutType,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightColor {
+    xy: HueV2LightColorXY,
+    gamut: Option<HueV2LightColorGamut>,
+    gamut_type: HueV2LightColorGamutType,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightDynamicsStatus {
     DynamicPalette,
     None,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetDynamics {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightDynamics {
     status: HueV2LightDynamicsStatus,
     status_values: Vec<String>,
     speed: f64,
     speed_valid: bool,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetAlert {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightAlert {
     action_values: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightSignal {
     NoSignal,
     OnOff,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetSignalingStatus {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightSignalingStatus {
     signal: HueV2LightSignal,
     estimated_end: String,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetSignaling {
-    status: Option<HueV2LightGetSignalingStatus>,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightSignaling {
+    status: Option<HueV2LightSignalingStatus>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightMode {
     Normal,
     Streaming,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetGradientColor {
-    xy: HueV2LightGetColorXY,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightGradientColor {
+    xy: HueV2LightColorXY,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetGradientPoint {
-    color: HueV2LightGetGradientColor,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightGradientPoint {
+    color: HueV2LightGradientColor,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightGradientMode {
     InterpolatedPalette,
@@ -429,16 +423,16 @@ pub enum HueV2LightGradientMode {
     RandomPixelated,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetGradient {
-    points: Vec<HueV2LightGetGradientPoint>,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightGradient {
+    points: Vec<HueV2LightGradientPoint>,
     mode: HueV2LightGradientMode,
     points_capable: u32,
     mode_values: Vec<String>,
     pixel_count: Option<u32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightEffect {
     Sparkle,
@@ -447,23 +441,23 @@ pub enum HueV2LightEffect {
     NoEffect,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetEffects {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightEffects {
     effect: HueV2LightEffect,
     status_values: Vec<String>,
     status: HueV2LightEffect,
     effect_values: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightTimedEffect {
     Sunrise,
     NoEffect,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetTimedEffects {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightTimedEffects {
     effect: HueV2LightTimedEffect,
     duration: Option<u32>,
     status_values: Vec<String>,
@@ -471,7 +465,7 @@ pub struct HueV2LightGetTimedEffects {
     effect_values: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightPowerupPreset {
     Safety,
@@ -480,7 +474,7 @@ pub enum HueV2LightPowerupPreset {
     Custom,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightPowerupOnMode {
     On,
@@ -488,31 +482,31 @@ pub enum HueV2LightPowerupOnMode {
     Previous,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetPowerupOn {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightPowerupOn {
     mode: HueV2LightPowerupOnMode,
-    on: Option<HueV2LightGetOn>,
+    on: Option<HueV2LightOn>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightPowerupDimmingMode {
     Dimming,
     Previous,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetPowerupDimmingBrightness {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightPowerupDimmingBrightness {
     brightness: f64,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetPowerupDimming {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightPowerupDimming {
     mode: HueV2LightPowerupDimmingMode,
-    dimming: Option<HueV2LightGetPowerupDimmingBrightness>,
+    dimming: Option<HueV2LightPowerupDimmingBrightness>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2LightColorTemperatureMode {
     ColorTemperature,
@@ -520,60 +514,60 @@ pub enum HueV2LightColorTemperatureMode {
     Previous,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetPowerupColorTemperature {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightPowerupColorTemperature {
     mirek: u32,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetPowerupColorColor {
-    xy: HueV2LightGetColorXY,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightPowerupColorColor {
+    xy: HueV2LightColorXY,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetPowerupColor {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightPowerupColor {
     mode: HueV2LightColorTemperatureMode,
-    color_temperature: Option<HueV2LightGetPowerupColorTemperature>,
-    color: Option<HueV2LightGetPowerupColorColor>,
+    color_temperature: Option<HueV2LightPowerupColorTemperature>,
+    color: Option<HueV2LightPowerupColorColor>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGetPowerup {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightPowerup {
     preset: HueV2LightPowerupPreset,
     configured: bool,
-    on: HueV2LightGetPowerupOn,
-    dimming: Option<HueV2LightGetPowerupDimming>,
-    color: Option<HueV2LightGetPowerupColor>,
+    on: HueV2LightPowerupOn,
+    dimming: Option<HueV2LightPowerupDimming>,
+    color: Option<HueV2LightPowerupColor>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Light {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
-    metadata: HueV2LightGetMetadata,
-    on: HueV2LightGetOn,
-    dimming: Option<HueV2LightGetDimming>,
-    color_temperature: Option<HueV2LightGetColorTemperature>,
-    color: Option<HueV2LightGetColor>,
-    dynamics: Option<HueV2LightGetDynamics>,
-    alert: Option<HueV2LightGetAlert>,
-    signaling: Option<HueV2LightGetSignaling>,
+    owner: HueV2ResourceIdentifier,
+    metadata: HueV2LightMetadata,
+    on: HueV2LightOn,
+    dimming: Option<HueV2LightDimming>,
+    color_temperature: Option<HueV2LightColorTemperature>,
+    color: Option<HueV2LightColor>,
+    dynamics: Option<HueV2LightDynamics>,
+    alert: Option<HueV2LightAlert>,
+    signaling: Option<HueV2LightSignaling>,
     mode: HueV2LightMode,
-    gradient: Option<HueV2LightGetGradient>,
-    effects: Option<HueV2LightGetEffects>,
-    timed_effects: Option<HueV2LightGetTimedEffects>,
-    powerup: Option<HueV2LightGetPowerup>,
+    gradient: Option<HueV2LightGradient>,
+    effects: Option<HueV2LightEffects>,
+    timed_effects: Option<HueV2LightTimedEffects>,
+    powerup: Option<HueV2LightPowerup>,
 }
-hue_v2_res_get!(HueV2LightGet);
+hue_v2_res!(HueV2Light);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ButtonGetMetadata {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ButtonMetadata {
     control_id: u32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2ButtonEvent {
     InitialPress,
@@ -584,260 +578,260 @@ pub enum HueV2ButtonEvent {
     LongPress,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ButtonGetButton {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ButtonButton {
     last_event: HueV2ButtonEvent,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ButtonGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Button {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
-    metadata: HueV2ButtonGetMetadata,
-    button: HueV2ButtonGetButton,
+    owner: HueV2ResourceIdentifier,
+    metadata: HueV2ButtonMetadata,
+    button: HueV2ButtonButton,
 }
-hue_v2_res_get!(HueV2ButtonGet);
+hue_v2_res!(HueV2Button);
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2RelativeRotaryAction {
     Start,
     Repeat,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HueV2RelativeRotaryDirection {
     ClockWise,
     CounterClockWise,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2RelativeRotaryGetRelativeRotaryRotation {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2RelativeRotaryRotation {
     direction: HueV2RelativeRotaryDirection,
     steps: u32,
     duration: u32,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2RelativeRotaryGetRelativeRotaryEvent {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2RelativeRotaryEvent {
     action: HueV2RelativeRotaryAction,
-    rotation: HueV2RelativeRotaryGetRelativeRotaryRotation,
+    rotation: HueV2RelativeRotaryRotation,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2RelativeRotaryGetRelativeRotary {
-    last_event: Option<HueV2RelativeRotaryGetRelativeRotaryEvent>,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2RelativeRotaryInner {
+    last_event: Option<HueV2RelativeRotaryEvent>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2RelativeRotaryGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2RelativeRotary {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
-    relative_rotary: HueV2RelativeRotaryGetRelativeRotary,
+    owner: HueV2ResourceIdentifier,
+    relative_rotary: HueV2RelativeRotaryInner,
 }
-hue_v2_res_get!(HueV2RelativeRotaryGet);
+hue_v2_res!(HueV2RelativeRotary);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2TemperatureGetTemperature {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2TemperatureInner {
     temperature: f64,
     temperature_valid: bool,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2TemperatureGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Temperature {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
+    owner: HueV2ResourceIdentifier,
     enabled: bool,
-    temperature: HueV2TemperatureGetTemperature,
+    temperature: HueV2TemperatureInner,
 }
-hue_v2_res_get!(HueV2TemperatureGet);
+hue_v2_res!(HueV2Temperature);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightLevelGetLevel {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightLevelInner {
     light_level: u32,
     light_level_valid: bool,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2LightLevelGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2LightLevel {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
+    owner: HueV2ResourceIdentifier,
     enabled: bool,
-    light: HueV2LightLevelGetLevel,
+    light: HueV2LightLevelInner,
 }
-hue_v2_res_get!(HueV2LightLevelGet);
+hue_v2_res!(HueV2LightLevel);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2MotionGetMotion {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2MotionInner {
     motion: bool,
     motion_valid: bool,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2MotionGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Motion {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
+    owner: HueV2ResourceIdentifier,
     enabled: bool,
-    motion: HueV2MotionGetMotion,
+    motion: HueV2MotionInner,
 }
-hue_v2_res_get!(HueV2MotionGet);
+hue_v2_res!(HueV2Motion);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2EntertainmentGetSegment {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2EntertainmentSegment {
     start: u32,
     length: u32,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2EntertainmentGetSegments {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2EntertainmentSegments {
     configurable: bool,
     max_segments: u32,
-    segments: Vec<HueV2EntertainmentGetSegment>,
+    segments: Vec<HueV2EntertainmentSegment>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2EntertainmentGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Entertainment {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
+    owner: HueV2ResourceIdentifier,
     renderer: bool,
     proxy: bool,
     equalizer: bool,
     max_streams: Option<u32>,
-    segments: Option<HueV2EntertainmentGetSegments>,
+    segments: Option<HueV2EntertainmentSegments>,
 }
-hue_v2_res_get!(HueV2EntertainmentGet);
+hue_v2_res!(HueV2Entertainment);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2GroupedLightGetOn {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2GroupedLightOn {
     on: bool,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2GroupedLightGetDimming {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2GroupedLightDimming {
     dimming: f64,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2GroupedLightGetAlert {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2GroupedLightAlert {
     action_values: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2GroupedLightGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2GroupedLight {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
-    on: Option<HueV2GroupedLightGetOn>,
-    dimming: Option<HueV2GroupedLightGetDimming>,
-    alert: Option<HueV2GroupedLightGetAlert>,
+    owner: HueV2ResourceIdentifier,
+    on: Option<HueV2GroupedLightOn>,
+    dimming: Option<HueV2GroupedLightDimming>,
+    alert: Option<HueV2GroupedLightAlert>,
 }
-hue_v2_res_get!(HueV2GroupedLightGet);
+hue_v2_res!(HueV2GroupedLight);
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum HueV2DeviceBatteryState {
     Normal,
     Low,
     Critical,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2DevicePowerGetPowerState {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2DevicePowerState {
     battery_state: Option<HueV2DeviceBatteryState>,
     battery_level: Option<u32>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2DevicePowerGet {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2DevicePower {
     id: String,
     r#type: HueV2ResourceType,
     id_v1: Option<String>,
-    owner: HueV2ResourceIdentifierGet,
-    power_state: HueV2DevicePowerGetPowerState,
+    owner: HueV2ResourceIdentifier,
+    power_state: HueV2DevicePowerState,
 }
-hue_v2_res_get!(HueV2DevicePowerGet);
+hue_v2_res!(HueV2DevicePower);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ZigbeeBridgeConnectivityGet {}
-hue_v2_res_get!(HueV2ZigbeeBridgeConnectivityGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ZigbeeBridgeConnectivity {}
+hue_v2_res!(HueV2ZigbeeBridgeConnectivity);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ZigbeeConnectivityGet {}
-hue_v2_res_get!(HueV2ZigbeeConnectivityGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ZigbeeConnectivity {}
+hue_v2_res!(HueV2ZigbeeConnectivity);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ZgpConnectivityGet {}
-hue_v2_res_get!(HueV2ZgpConnectivityGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ZgpConnectivity {}
+hue_v2_res!(HueV2ZgpConnectivity);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2BridgeGet {}
-hue_v2_res_get!(HueV2BridgeGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Bridge {}
+hue_v2_res!(HueV2Bridge);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2ZigbeeDeviceDiscoveryGet {}
-hue_v2_res_get!(HueV2ZigbeeDeviceDiscoveryGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2ZigbeeDeviceDiscovery {}
+hue_v2_res!(HueV2ZigbeeDeviceDiscovery);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2HomekitGet {}
-hue_v2_res_get!(HueV2HomekitGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Homekit {}
+hue_v2_res!(HueV2Homekit);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2MatterGet {}
-hue_v2_res_get!(HueV2MatterGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Matter {}
+hue_v2_res!(HueV2Matter);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2MatterFabricGet {}
-hue_v2_res_get!(HueV2MatterFabricGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2MatterFabric {}
+hue_v2_res!(HueV2MatterFabric);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2SceneGet {}
-hue_v2_res_get!(HueV2SceneGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Scene {}
+hue_v2_res!(HueV2Scene);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2EntertainmentConfigurationGet {}
-hue_v2_res_get!(HueV2EntertainmentConfigurationGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2EntertainmentConfiguration {}
+hue_v2_res!(HueV2EntertainmentConfiguration);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2PublicImageGet {}
-hue_v2_res_get!(HueV2PublicImageGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2PublicImage {}
+hue_v2_res!(HueV2PublicImage);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2AuthV1Get {}
-hue_v2_res_get!(HueV2AuthV1Get);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2AuthV1 {}
+hue_v2_res!(HueV2AuthV1);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2BehaviorScriptGet {}
-hue_v2_res_get!(HueV2BehaviorScriptGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2BehaviorScript {}
+hue_v2_res!(HueV2BehaviorScript);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2BehaviorInstanceGet {}
-hue_v2_res_get!(HueV2BehaviorInstanceGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2BehaviorInstance {}
+hue_v2_res!(HueV2BehaviorInstance);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2GeofenceGet {}
-hue_v2_res_get!(HueV2GeofenceGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Geofence {}
+hue_v2_res!(HueV2Geofence);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2GeofenceClientGet {}
-hue_v2_res_get!(HueV2GeofenceClientGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2GeofenceClient {}
+hue_v2_res!(HueV2GeofenceClient);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2GeolocationGet {}
-hue_v2_res_get!(HueV2GeolocationGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2Geolocation {}
+hue_v2_res!(HueV2Geolocation);
 
-#[derive(Debug, Deserialize)]
-pub struct HueV2SmartSceneGet {}
-hue_v2_res_get!(HueV2SmartSceneGet);
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HueV2SmartScene {}
+hue_v2_res!(HueV2SmartScene);

--- a/src-tauri/transfer.rs
+++ b/src-tauri/transfer.rs
@@ -1,0 +1,201 @@
+#![allow(unused)]
+
+use core::fmt::Debug;
+use paste::paste;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2Error {
+    description: String,
+}
+
+pub trait HueV2ResGet: Debug {}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ResourceApi<F: HueV2ResGet> {
+    errors: Vec<HueV2Error>,
+    data: Vec<F>,
+}
+
+macro_rules! hue_v2_resp {
+    ($v:ident) => {
+        paste! {
+            pub type [<$v Response>] = HueV2ResourceApi<$v>;
+        }
+    };
+}
+
+macro_rules! hue_v2_res_get {
+    ($v:ident) => {
+        impl HueV2ResGet for $v {}
+
+        hue_v2_resp!($v);
+    };
+}
+
+#[derive(Debug, Deserialize)]
+pub enum HueV2ResourceGetType {
+    Device,
+    BridgeHome,
+    Room,
+    Zone,
+    Light,
+    Button,
+    RelativeRotary,
+    Temperature,
+    LightLevel,
+    Motion,
+    Entertainment,
+    GroupedLight,
+    DevicePower,
+    ZigbeeBridgeConnectivity,
+    ZigbeeConnectivity,
+    ZgpConnectivity,
+    Bridge,
+    ZigbeeDeviceDiscovery,
+    Homekit,
+    Matter,
+    MatterFabric,
+    Scene,
+    EntertainmentConfiguration,
+    PublicImage,
+    AuthV1,
+    BehaviorScript,
+    BehaviorInstance,
+    Geofence,
+    GeofenceClient,
+    Geolocation,
+    SmartScene,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ResourceGet {
+    id: String,
+    r#type: HueV2ResourceGetType,
+    id_v1: String,
+}
+hue_v2_res_get!(HueV2ResourceGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2DeviceGet {}
+hue_v2_res_get!(HueV2DeviceGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2BridgeHomeGet {}
+hue_v2_res_get!(HueV2BridgeHomeGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RoomGet {}
+hue_v2_res_get!(HueV2RoomGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ZoneGet {}
+hue_v2_res_get!(HueV2ZoneGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightGet {}
+hue_v2_res_get!(HueV2LightGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ButtonGet {}
+hue_v2_res_get!(HueV2ButtonGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2RelativeRotaryGet {}
+hue_v2_res_get!(HueV2RelativeRotaryGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2TemperatureGet {}
+hue_v2_res_get!(HueV2TemperatureGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2LightLevelGet {}
+hue_v2_res_get!(HueV2LightLevelGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2MotionGet {}
+hue_v2_res_get!(HueV2MotionGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2EntertainmentGet {}
+hue_v2_res_get!(HueV2EntertainmentGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2GroupedLightGet {}
+hue_v2_res_get!(HueV2GroupedLightGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2DevicePowerGet {}
+hue_v2_res_get!(HueV2DevicePowerGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ZigbeeBridgeConnectivityGet {}
+hue_v2_res_get!(HueV2ZigbeeBridgeConnectivityGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ZigbeeConnectivityGet {}
+hue_v2_res_get!(HueV2ZigbeeConnectivityGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ZgpConnectivityGet {}
+hue_v2_res_get!(HueV2ZgpConnectivityGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2BridgeGet {}
+hue_v2_res_get!(HueV2BridgeGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2ZigbeeDeviceDiscoveryGet {}
+hue_v2_res_get!(HueV2ZigbeeDeviceDiscoveryGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2HomekitGet {}
+hue_v2_res_get!(HueV2HomekitGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2MatterGet {}
+hue_v2_res_get!(HueV2MatterGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2MatterFabricGet {}
+hue_v2_res_get!(HueV2MatterFabricGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2SceneGet {}
+hue_v2_res_get!(HueV2SceneGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2EntertainmentConfigurationGet {}
+hue_v2_res_get!(HueV2EntertainmentConfigurationGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2PublicImageGet {}
+hue_v2_res_get!(HueV2PublicImageGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2AuthV1Get {}
+hue_v2_res_get!(HueV2AuthV1Get);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2BehaviorScriptGet {}
+hue_v2_res_get!(HueV2BehaviorScriptGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2BehaviorInstanceGet {}
+hue_v2_res_get!(HueV2BehaviorInstanceGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2GeofenceGet {}
+hue_v2_res_get!(HueV2GeofenceGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2GeofenceClientGet {}
+hue_v2_res_get!(HueV2GeofenceClientGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2GeolocationGet {}
+hue_v2_res_get!(HueV2GeolocationGet);
+
+#[derive(Debug, Deserialize)]
+pub struct HueV2SmartSceneGet {}
+hue_v2_res_get!(HueV2SmartSceneGet);


### PR DESCRIPTION
this commit refactors the existing discovery logic into a more nicely
encapsulated abstraction with which we can build a nice http client that
can be used by tauri handlers
