### PR TITLE
feat:add `clap` argument parser ops:generate typescript bindings before prod build

### DIFF
--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -32,20 +32,22 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: generate typescript bindings
+        run: cd src-tauri && cargo run --release -- --generate-bindings-only
       - name: install frontend dependencies
         run: yarn install
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Tarpaulin
-        run: cd src-tauri && cargo install cargo-tarpaulin
-        continue-on-error: true
+      - name: Run cargo:test
+        run: cd src-tauri && cargo test --verbose --all-features
       - name: Run cargo:fmt
         run: cd src-tauri && cargo fmt --all -- --check
       - name: Run cargo:clippy
         run: cd src-tauri && cargo clippy --all-features -- -D warnings
-      - name: Run cargo:test
-        run: cd src-tauri && cargo test --verbose --all-features
+      - name: Setup Tarpaulin
+        run: cd src-tauri && cargo install cargo-tarpaulin
+        continue-on-error: true
       - name: Run cargo:tarpaulin
         run: cd src-tauri && cargo tarpaulin --verbose --all-features --out Xml --output-dir ./coverage
       - name: Codecov
@@ -172,6 +174,8 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
       - name: pull latest commit
         run: git pull
+      - name: generate typescript bindings
+        run: cd src-tauri && cargo run --release -- --generate-bindings-only
       - name: install frontend dependencies
         run: yarn install
       - uses: tauri-apps/tauri-action@v0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -63,6 +63,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +510,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +586,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -1496,6 +1592,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 name = "huehuehue"
 version = "0.0.1"
 dependencies = [
+ "clap",
  "env_logger",
  "futures-util",
  "log",
@@ -3837,6 +3934,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "huehuehue"
 version = "0.0.1"
-description = "A Tauri App"
-authors = ["you"]
+description = "A Tauri App to manage your Philips Hue devices from anywhere"
+authors = [
+    "Kyrill Gobber <kyrill@gobber.ch>",
+    "Soryn Bächli <>",
+    "Cedric Schwyter <cedricschwyter@bluewin.ch>",
+]
 license = ""
-repository = ""
+repository = "https://github.com/KyrillGobber/huehuehue"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -36,6 +40,7 @@ serde_derive = "1.0.164"
 thiserror = "1.0.40"
 specta = "1.0.4"
 tauri-specta = { version = "1.0.2", features = ["javascript", "typescript"] }
+clap = { version = "4.3.10", features = ["derive"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/core/macros.rs
+++ b/src-tauri/core/macros.rs
@@ -88,7 +88,6 @@ macro_rules! handlers {
         #[macro_export]
         macro_rules! bindings {
             ($path:expr) => {
-                #[cfg(debug_assertions)]
                 tauri_specta::ts::export(specta::collect_types![$($handler,)*], $path).unwrap();
             };
         }

--- a/src-tauri/lib.rs
+++ b/src-tauri/lib.rs
@@ -1,5 +1,6 @@
 pub mod core;
 
+use clap::Parser;
 use futures_util::{pin_mut, stream::StreamExt};
 use log::info;
 use mdns::RecordKind;
@@ -12,12 +13,22 @@ const HUE_BRIDGE_SERVICE_NAME: &str = "_hue._tcp.local";
 const HUE_BRIDGE_SERVICE_QUERY_INTERVAL_SECONDS: u64 = 3600;
 const HUE_BRIDGE_API_BASE_URL: &str = "/clip/v2";
 
-#[derive(Debug, Default)]
-pub struct HueHueHueConfig {}
+#[derive(Clone, Debug, Parser)]
+#[command(author, version, about)]
+pub struct HueHueHueConfig {
+    #[arg(long)]
+    pub generate_bindings_only: bool,
+}
+
+impl Default for HueHueHueConfig {
+    fn default() -> Self {
+        HueHueHueConfig::parse()
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct HueHueHue {
-    _config: HueHueHueConfig,
+    config: HueHueHueConfig,
     bridge_ip_addrs: Arc<Mutex<HashSet<IpAddr>>>,
     client: Client,
 }
@@ -42,6 +53,10 @@ impl serde::Serialize for HueHueHueError {
 }
 
 impl HueHueHue {
+    pub fn get_config(&self) -> HueHueHueConfig {
+        self.config.clone()
+    }
+
     fn get_base_url(&self) -> String {
         // TODO: compute the actual base url using the currently selected bridge device
         HUE_BRIDGE_API_BASE_URL.to_string()

--- a/src-tauri/main.rs
+++ b/src-tauri/main.rs
@@ -11,16 +11,28 @@ use log::info;
 use tauri::RunEvent;
 use tokio::sync::Mutex;
 
+const TS_BINDINGS_FILE: &str = "../src/bindings.ts";
+
 #[tokio::main]
 pub async fn main() -> Result<(), HueHueHueError> {
     env_logger::init_from_env(
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
     );
     tauri::async_runtime::set(tokio::runtime::Handle::current());
-    info!("starting huehuehue...");
     let huehuehue: HueHueHue = HueHueHue::default();
+    info!("run config: {:?}", huehuehue.get_config());
+    if huehuehue.get_config().generate_bindings_only {
+        info!("generating bindings to \"{}\"", TS_BINDINGS_FILE);
+        bindings!(TS_BINDINGS_FILE);
+        info!(
+            "successfully generated bindings to \"{}\"",
+            TS_BINDINGS_FILE
+        );
+
+        return Ok(());
+    }
+    info!("starting huehuehue...");
     huehuehue.discover()?;
-    bindings!("../src/bindings.ts");
     huehuehue_handlers!(tauri::Builder::default())
         .manage(HueHueHueState(Mutex::new(huehuehue)))
         .build(tauri::generate_context!())

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+bindings.ts


### PR DESCRIPTION
this commit introduces the `clap` crate - the command line argument
parser library. with it we can now run the tauri backend with the
`--generate-bindings-only` flag to only output the typescript bindings
and then exit the program. this, we can now use to generate typescript
bindings freshly before every production build. i have also went ahead
and added the generated `src/bindings.ts` file to `.gitignore` so as not
to track it and forcing people to generate it anew on every build.
