### PR TITLE
chore:switch to rust nightly refactor:higher-order http method macro

### DIFF
--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: nightly
       - name: Setup Cache
         uses: actions/cache@v3
         continue-on-error: false
@@ -69,7 +69,7 @@ jobs:
         run: yarn install
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
       - uses: actions-rs/cargo@v1
         with:
           command: install
@@ -163,8 +163,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
         run: |

--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -32,21 +32,23 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: install cargo-fmt
+        run: rustup component add rustfmt
+      - name: install cargo-clippy
+        run: rustup component add clippy
+      - name: run cargo:fmt
+        run: cd src-tauri && cargo fmt --all -- --check
       - name: install frontend dependencies
         run: yarn install
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run cargo:test
-        run: cd src-tauri && cargo test --verbose --all-features
-      - name: Run cargo:fmt
-        run: cd src-tauri && cargo fmt --all -- --check
-      - name: Run cargo:clippy
+      - name: run cargo:clippy
         run: cd src-tauri && cargo clippy --all-features -- -D warnings
-      - name: Setup Tarpaulin
+      - name: setup Tarpaulin
         run: cd src-tauri && cargo install cargo-tarpaulin
         continue-on-error: true
-      - name: Run cargo:tarpaulin
+      - name: run cargo:tarpaulin (runs cargo test)
         run: cd src-tauri && cargo tarpaulin --verbose --all-features --out Xml --output-dir ./coverage
       - name: Codecov
         uses: codecov/codecov-action@v3

--- a/src-tauri/core/macros.rs
+++ b/src-tauri/core/macros.rs
@@ -29,59 +29,25 @@ macro_rules! endpoint {
     };
 }
 
-macro_rules! get {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(get, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
+macro_rules! http_method {
+    ($method:ident) => {
+        macro_rules! $method {
+            ($$endpoint:expr, $$endpointname:ident, $$returntype:ident $$(, $$body:ident)? $$(, [$$($$param:expr),+])?) => {
+                endpoint!($method, $$endpoint, $$endpointname, $returntype $$(, $$body)? $$(, [$$($$param),+])?);
+            };
+        }
     };
 }
 
-macro_rules! head {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(head, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
-
-macro_rules! post {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(post, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
-
-macro_rules! put {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(put, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
-
-macro_rules! delete {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(delete, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
-
-macro_rules! connect {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(connect, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
-
-macro_rules! options {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(options, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
-
-macro_rules! trace {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(trace, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
-
-macro_rules! patch {
-    ($endpoint:expr, $endpointname:ident, $returntype:ident $(, $body:ident)? $(, [$($param:expr),+])?) => {
-        endpoint!(patch, $endpoint, $endpointname, $returntype $(, $body)? $(, [$($param),+])?);
-    };
-}
+http_method!(get);
+http_method!(head);
+http_method!(post);
+http_method!(put);
+http_method!(delete);
+http_method!(connect);
+http_method!(options);
+http_method!(trace);
+http_method!(patch);
 
 macro_rules! handlers {
     ($($handler:ident),*) => {

--- a/src-tauri/lib.rs
+++ b/src-tauri/lib.rs
@@ -14,7 +14,7 @@ const HUE_BRIDGE_SERVICE_NAME: &str = "_hue._tcp.local";
 const HUE_BRIDGE_SERVICE_QUERY_INTERVAL_SECONDS: u64 = 3600;
 const HUE_BRIDGE_API_BASE_URL: &str = "/clip/v2";
 
-#[derive(Clone, Debug, Parser)]
+#[derive(Debug, Parser)]
 #[command(author, version, about)]
 pub struct HueHueHueConfig {
     #[arg(long)]
@@ -54,8 +54,8 @@ impl serde::Serialize for HueHueHueError {
 }
 
 impl HueHueHue {
-    pub fn get_config(&self) -> HueHueHueConfig {
-        self.config.clone()
+    pub fn get_config(&self) -> &HueHueHueConfig {
+        &self.config
     }
 
     fn get_base_url(&self) -> String {

--- a/src-tauri/lib.rs
+++ b/src-tauri/lib.rs
@@ -1,3 +1,4 @@
+#![feature(macro_metavar_expr)]
 pub mod core;
 
 use clap::Parser;

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
we want to switch to rust nightly to be able to make use of rust
metavariable expansions as defined by RFC rust-lang/rfcs#3086 and
as tracked by rust-lang/rust#83527. other references include
rust-lang/rust#99035.

this feature was stabilized in 1.63, then unstabilized again in
rust-lang/rust#99435 and is now only available in rust nightly, awaiting
restabilization. however, the feature is stable enough for our use case,
which is why i'm going ahead and enabling it.
