### PR TITLE
refactor:move argument parsing to executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "build:client": "vite build",
         "preview": "vite preview",
         "check": "svelte-check --tsconfig ./tsconfig.json",
-        "bindings:debug": "cd src-tauri && cargo run -q -- --generate-bindings-only",
-        "bindings:release": "cd src-tauri && cargo run -q --release -- --generate-bindings-only",
+        "bindings:debug": "cd src-tauri && cargo run -q -- generate-bindings --only",
+        "bindings:release": "cd src-tauri && cargo run -q --release -- generate-bindings --only",
         "dev": "yarn run bindings:debug && tauri dev",
         "build": "yarn run bindings:release && tauri build",
         "release": "standard-version"

--- a/src-tauri/lib.rs
+++ b/src-tauri/lib.rs
@@ -1,7 +1,6 @@
 #![feature(macro_metavar_expr)]
 pub mod core;
 
-use clap::Parser;
 use futures_util::{pin_mut, stream::StreamExt};
 use log::info;
 use mdns::RecordKind;
@@ -14,22 +13,12 @@ const HUE_BRIDGE_SERVICE_NAME: &str = "_hue._tcp.local";
 const HUE_BRIDGE_SERVICE_QUERY_INTERVAL_SECONDS: u64 = 3600;
 const HUE_BRIDGE_API_BASE_URL: &str = "/clip/v2";
 
-#[derive(Debug, Parser)]
-#[command(author, version, about)]
-pub struct HueHueHueConfig {
-    #[arg(long)]
-    pub generate_bindings_only: bool,
-}
-
-impl Default for HueHueHueConfig {
-    fn default() -> Self {
-        HueHueHueConfig::parse()
-    }
-}
+#[derive(Debug, Default)]
+pub struct HueHueHueBackendConfig {}
 
 #[derive(Debug, Default)]
 pub struct HueHueHue {
-    config: HueHueHueConfig,
+    _config: HueHueHueBackendConfig,
     bridge_ip_addrs: Arc<Mutex<HashSet<IpAddr>>>,
     client: Client,
 }
@@ -54,8 +43,11 @@ impl serde::Serialize for HueHueHueError {
 }
 
 impl HueHueHue {
-    pub fn get_config(&self) -> &HueHueHueConfig {
-        &self.config
+    pub fn with_config(config: impl Into<HueHueHueBackendConfig>) -> HueHueHue {
+        HueHueHue {
+            _config: config.into(),
+            ..Default::default()
+        }
     }
 
     fn get_base_url(&self) -> String {

--- a/src-tauri/main.rs
+++ b/src-tauri/main.rs
@@ -1,14 +1,59 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use clap::{Args, Parser, Subcommand};
 use huehuehue::{
-    bindings, core::handlers::*, huehuehue_handlers, HueHueHue, HueHueHueError, HueHueHueState,
+    bindings, core::handlers::*, huehuehue_handlers, HueHueHue, HueHueHueBackendConfig,
+    HueHueHueError, HueHueHueState,
 };
 use log::info;
 use tauri::RunEvent;
 use tokio::sync::Mutex;
 
-const TS_BINDINGS_FILE: &str = "../src/bindings.ts";
+#[derive(Debug, Parser)]
+#[command(author, version, about)]
+struct HueHueHueConfig {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+impl From<HueHueHueConfig> for HueHueHueBackendConfig {
+    fn from(_val: HueHueHueConfig) -> Self {
+        HueHueHueBackendConfig::default()
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    GenerateBindings(BindingsConfig),
+}
+
+#[derive(Debug, Args)]
+struct BindingsConfig {
+    #[arg(short = 'O', long)]
+    only: bool,
+    #[arg(short = 'o', long, default_value = "../src/bindings.ts")]
+    output: String,
+}
+
+/// returns `true` if the executable should exit after running the command
+async fn command(command: &Command) -> Result<bool, HueHueHueError> {
+    info!("running command config: {:?}", command);
+    match command {
+        Command::GenerateBindings(bindings_config) => {
+            let path = bindings_config.output.as_str();
+            info!("generating bindings to \"{}\"", path);
+            bindings!(path);
+            info!("successfully generated bindings to \"{}\"", path);
+
+            if bindings_config.only {
+                return Ok(true);
+            }
+        }
+    };
+
+    Ok(false)
+}
 
 #[tokio::main]
 pub async fn main() -> Result<(), HueHueHueError> {
@@ -16,18 +61,14 @@ pub async fn main() -> Result<(), HueHueHueError> {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
     );
     tauri::async_runtime::set(tokio::runtime::Handle::current());
-    let huehuehue: HueHueHue = HueHueHue::default();
-    info!("run config: {:?}", huehuehue.get_config());
-    if huehuehue.get_config().generate_bindings_only {
-        info!("generating bindings to \"{}\"", TS_BINDINGS_FILE);
-        bindings!(TS_BINDINGS_FILE);
-        info!(
-            "successfully generated bindings to \"{}\"",
-            TS_BINDINGS_FILE
-        );
-
-        return Ok(());
+    let config = HueHueHueConfig::parse();
+    info!("run config: {:?}", config);
+    if let Some(com) = &config.command {
+        if command(com).await? {
+            return Ok(());
+        }
     }
+    let huehuehue: HueHueHue = HueHueHue::with_config(config);
     info!("starting huehuehue...");
     huehuehue.discover()?;
     huehuehue_handlers!(tauri::Builder::default())


### PR DESCRIPTION
this commit moves the argument parsing logic to the actual executable,
where it should be. it also introduces the `generate-bindings`
subcommand to facilitate the generation of the typescript bindings that
was previously specified using flags at the top-level of the argument
parsing tree
