### PR TITLE
ops:introduce deploy key

### DIFF
--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -63,6 +65,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: setup node
         uses: actions/setup-node@v3
         with:
@@ -104,6 +108,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: setup node
         uses: actions/setup-node@v3
         with:
@@ -161,6 +167,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
this change is necessary to be able to push commits from github actions
to protected branches.
