### PR TITLE
feat: provide `abortDiscover` handler feat: abort service discovery once bridge selected

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.0.4"
 description = "A Tauri App to manage your Philips Hue devices from anywhere"
 authors = [
     "Kyrill Gobber <kyrill@gobber.ch>",
-    "Soryn Bächli <>",
-    "Cedric Schwyter <cedricschwyter@bluewin.ch>",
+    "Soryn Bächli <contact@soryn.dev>",
+    "Cedric Schwyter <cedric@schwyter.io>",
 ]
 license = ""
 repository = "https://github.com/KyrillGobber/huehuehue"

--- a/src-tauri/core/handlers.rs
+++ b/src-tauri/core/handlers.rs
@@ -228,7 +228,7 @@ pub async fn set_selected_bridge(
     state: State<'_, HueHueHueState>,
 ) -> Result<(), HueHueHueError> {
     let mut huehuehue = state.0.lock().await;
-    huehuehue.set_selected_bridge(mdns_name);
+    huehuehue.set_selected_bridge(mdns_name)?;
 
     Ok(())
 }
@@ -246,6 +246,14 @@ pub async fn get_discovered_bridges(
         .iter()
         .map(|(k, v)| (k.clone(), *v))
         .collect())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn abort_discover(state: State<'_, HueHueHueState>) -> Result<(), HueHueHueError> {
+    let mut huehuehue = state.0.lock().await;
+
+    huehuehue.abort_discover()
 }
 
 handlers!(
@@ -304,5 +312,6 @@ handlers!(
     get_smart_scenes,
     get_smart_scene,
     set_selected_bridge,
-    get_discovered_bridges
+    get_discovered_bridges,
+    abort_discover
 );

--- a/src-tauri/main.rs
+++ b/src-tauri/main.rs
@@ -82,7 +82,7 @@ pub async fn main() -> Result<(), HueHueHueError> {
             return Ok(());
         }
     }
-    let huehuehue: HueHueHue = HueHueHue::with_config(&config);
+    let mut huehuehue: HueHueHue = HueHueHue::with_config(&config);
     info!("starting huehuehue...");
     huehuehue.discover();
     huehuehue_handlers!(tauri::Builder::default())


### PR DESCRIPTION
this change implements functionality that aborts the discovery daemon
once a bridge has been selected. we also provide a dedicated
`abortDiscover` handler so that the discovery daemon may be started and
stopped at will.
